### PR TITLE
feat: allow cross origin requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"compression": "^1.7.4",
 		"fastify": "^2.12.0",
 		"fastify-compress": "^2.0.1",
+		"fastify-cors": "^3.0.2",
 		"fastify-static": "^2.6.0",
 		"glob": "^7.1.6",
 		"lru-cache": "^5.1.1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@
 import fastify, { ServerOptionsAsHttp2, ServerOptionsAsSecureHttp2 } from 'fastify';
 import fastifyCompress from 'fastify-compress';
 import fastifyStatic from 'fastify-static';
+import fastifyCors from 'fastify-cors';
 import { readFileSync } from 'fs';
 import cssBundler from './cssBundler';
 import config from './config';
@@ -36,6 +37,11 @@ const app = fastify(
 if (!proxied) {
 	app.register(fastifyCompress, { global: true });
 }
+
+app.register(fastifyCors, {
+	origin: true,
+	methods: ['GET'],
+});
 
 app.register(fastifyStatic, {
 	root: resolve(staticFolder),


### PR DESCRIPTION
This PR sets fastify-cors `origin` option to `true`. Which will make the `access-control-allow-origin` header reflect the request origin.

Without the proper allow-origin headers `.woff` files will be blocked by CORS.